### PR TITLE
SyntaxError Fix

### DIFF
--- a/app/templates/src/components/Counter.js
+++ b/app/templates/src/components/Counter.js
@@ -8,7 +8,7 @@ export default class Counter extends Component {
     incrementAsync: PropTypes.func.isRequired,
     decrement: PropTypes.func.isRequired,
     counter: PropTypes.number.isRequired
-  }
+  };
 
   render() {
     const { increment, incrementIfOdd, incrementAsync, decrement, counter } = this.props;


### PR DESCRIPTION
Initially, if you try to run `npm test` on a recently generated project, the following error appear:
```
SyntaxError: .../src/components/Counter.js: A semicolon is required after a class property (11:3)
   9   |     decrement: PropTypes.func.isRequired,
  10  |     counter: PropTypes.number.isRequired
> 11 |   }
        |    ^
```

Adding the semicolon solves the problem.